### PR TITLE
Feature/initial-search-state

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,30 @@ AfostoInstantSearchWidget.addMessages('en', {
     resultsLabel: '{value} results found',
   },
 });
+```
 
+### Initial search state
+It is possible to set an initial search state. With it, you can define the initial state of filters and the query.
+For a reference of the available options within the searchState, check the [documentation](https://www.algolia.com/doc/api-reference/widgets/ui-state/react/).
+
+```js
+AfostoInstantSearchWidget.init('my-search-engine-key', {
+  searchState: {
+    // set te initial query to 'phone'
+    query: 'phone',
+    // set the brand filter to initial option 'Apple' 
+    refinementList: {
+      brand: ['Apple'],
+    },
+    // set the range filter price to initial range between 20 and 500
+    range: {
+      price: {
+        min: 20,
+        max: 500
+      }
+    },
+  },
+});
 ```
 
 ### Customizing the design

--- a/src/components/Widget/Widget.js
+++ b/src/components/Widget/Widget.js
@@ -18,6 +18,8 @@ const MotionDialogOverlay = m(DialogOverlay);
 const MotionDialogContent = m(DialogContent);
 
 const Widget = ({ config, locale, searchKey, translations }) => {
+  const { searchState: initialSearchState, hideFilters } = config || {};
+  const [searchState, setSearchState] = useState(initialSearchState);
   const [open, setOpen] = useState(false);
   const [showFilters, setShowFilters] = useState(false);
   const { client, isFetchingSettings, settings } = useClientSetup(searchKey);
@@ -38,7 +40,18 @@ const Widget = ({ config, locale, searchKey, translations }) => {
   useVisibilityListener(handleVisibilityEvent);
 
   return (
-    <WidgetProvider value={{ client, config, isFetchingSettings, locale, settings, translations, showFilters, setShowFilters }}>
+    <WidgetProvider
+      value={{
+        client,
+        config,
+        isFetchingSettings,
+        locale,
+        settings,
+        translations,
+        showFilters,
+        setShowFilters,
+      }}
+    >
       <LazyMotion features={domAnimation}>
         <AnimatePresence>
           {open && (
@@ -72,8 +85,14 @@ const Widget = ({ config, locale, searchKey, translations }) => {
                 >
                   <div className="af-is-widget__layout">
                     <CloseButton onClick={handleClose} />
-                    <InstantSearch indexName={mainIndex?.alias} searchClient={client}>
-                      <Filters />
+                    <InstantSearch
+                      indexName={mainIndex?.alias}
+                      searchClient={client}
+                      {...(typeof searchState === 'object'
+                        ? { searchState, onSearchStateChange: newState => setSearchState(newState) }
+                        : {})}
+                    >
+                      <Filters hideFilters={hideFilters} />
                       <SearchBox onClose={handleClose} />
                       <HitsPerPage />
                       <Hits />


### PR DESCRIPTION
Adds an optional `searchState` object to pass to `<InstantSearch />`. This will set an initial state for the widget. This way you can add default filters and set a query to start with.